### PR TITLE
Syntax Error, Refrences:

### DIFF
--- a/ch06/library_app/models/library_book.py
+++ b/ch06/library_app/models/library_book.py
@@ -10,7 +10,7 @@ class Book(models.Model):
     _description = "Book"
     # ch06:
     _order = "name, date_published desc"
-    _recname = "name"
+    _rec_name = "name"
     _table = "library_book"
     _log_access = True
     _auto = True

--- a/ch08/library_app/models/library_book.py
+++ b/ch08/library_app/models/library_book.py
@@ -10,7 +10,7 @@ class Book(models.Model):
     _description = "Book"
     # ch06:
     _order = "name, date_published desc"
-    _recname = "name"
+    _rec_name = "name"
     _table = "library_book"
     _log_access = True
     _auto = True

--- a/ch10/library_app/models/library_book.py
+++ b/ch10/library_app/models/library_book.py
@@ -10,7 +10,7 @@ class Book(models.Model):
     _description = "Book"
     # ch06:
     _order = "name, date_published desc"
-    _recname = "name"
+    _rec_name = "name"
     _table = "library_book"
     _log_access = True
     _auto = True


### PR DESCRIPTION
Dear Mr. Daniel,
I found a syntax error inside the book on page 176 which is: _recname = "name", but the actual syntax should be:
_rec_name = "name"

I also found the same error in the repository, then I modified it, and I am sending a pull request for my modification.

I am also looking forward to assisting you and tracking any other issues in the book or in the code. By the way, I filled out the form related to the book review on Linkedin and I am happy if you need me to review any future books.

Best Regards, Mohamed Alkobrosli

https://www.odoo.com/documentation/15.0/developer/reference/backend/orm.html?highlight=_rec_name#odoo.models.BaseModel._rec_name

https://github.com/odoo/odoo/blob/756101db7c2a579bf9b79ee5a722523784b2e351/addons/crm/models/crm_stage.py#L22